### PR TITLE
fixed typo in login_form template to  system.css stylesheet link

### DIFF
--- a/plugins/MidCentury/templates/login_form.mtml
+++ b/plugins/MidCentury/templates/login_form.mtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" id="sixapart-standard" xmlns:fb="http://www.facebook.com/2008/fbml">
 <head>
     <title>Sign In - <$mt:BlogName encode_html="1"$></title>
-    <link rel="stylesheet" href="<$mt:PluginStaticWebPath component="MidCentury$>system.css" type="text/css" />
+    <link rel="stylesheet" href="<$mt:PluginStaticWebPath component="MidCentury"$>system.css" type="text/css" />
     <$mt:include module="HTML Head"$>
     <script type="text/javascript"> 
     /* <![CDATA[ */ 


### PR DESCRIPTION
Missing closing apostrophe broke the link to system.css in the login form (used in Contact Form plugin)
